### PR TITLE
Fix Int overflow and forgetten Anyobject

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - Nimble (5.0.0)
   - Quick (0.10.0)
   - Starscream (2.0.0)
-  - Swamp (0.1.2):
+  - Swamp (0.2.0):
     - CryptoSwift (~> 0.6.0)
     - Starscream (~> 2.0.0)
     - SwiftyJSON (~> 3.1.0)
@@ -23,7 +23,7 @@ SPEC CHECKSUMS:
   Nimble: 56fc9f5020effa2206de22c3dd910f4fb011b92f
   Quick: 5d290df1c69d5ee2f0729956dcf0fd9a30447eaa
   Starscream: 947c865596f0d6bb3f0203fee23228ed2d471468
-  Swamp: 0eccf7f7d38e71d67aa7c251664f6e13b8604923
+  Swamp: c702bf2d26f3e4d379321a481fcd807037e173fc
   SwiftyJSON: 29b9f2a64f118c07e691667c2ba1efe536acfe0b
 
 PODFILE CHECKSUM: e3b6ef0c1caa7b4561126a7c54ecbe4decc7f9bc

--- a/Example/Pods/Local Podspecs/Swamp.podspec.json
+++ b/Example/Pods/Local Podspecs/Swamp.podspec.json
@@ -1,8 +1,8 @@
 {
   "name": "Swamp",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "summary": "WAMP protocol implementation in swift",
-  "description": "the WAMP WebSocket subprotocol implemented purely in Swift using Starscream, SwiftyJSON & SwiftPack",
+  "description": "the WAMP WebSocket subprotocol implemented purely in Swift using Starscream, SwiftyJSON",
   "homepage": "https://github.com/iscriptology/Swamp",
   "license": {
     "type": "MIT",
@@ -12,8 +12,8 @@
     "Yossi Abraham": "yo.ab@outlook.com"
   },
   "source": {
-    "git": "https://github.com/danysousa/swamp.git",
-    "tag": "0.1.2"
+    "git": "https://github.com/iscriptology/Swamp.git",
+    "tag": "0.2.0"
   },
   "platforms": {
     "ios": "8.0",

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -3,7 +3,7 @@ PODS:
   - Nimble (5.0.0)
   - Quick (0.10.0)
   - Starscream (2.0.0)
-  - Swamp (0.1.2):
+  - Swamp (0.2.0):
     - CryptoSwift (~> 0.6.0)
     - Starscream (~> 2.0.0)
     - SwiftyJSON (~> 3.1.0)
@@ -23,7 +23,7 @@ SPEC CHECKSUMS:
   Nimble: 56fc9f5020effa2206de22c3dd910f4fb011b92f
   Quick: 5d290df1c69d5ee2f0729956dcf0fd9a30447eaa
   Starscream: 947c865596f0d6bb3f0203fee23228ed2d471468
-  Swamp: 0eccf7f7d38e71d67aa7c251664f6e13b8604923
+  Swamp: c702bf2d26f3e4d379321a481fcd807037e173fc
   SwiftyJSON: 29b9f2a64f118c07e691667c2ba1efe536acfe0b
 
 PODFILE CHECKSUM: e3b6ef0c1caa7b4561126a7c54ecbe4decc7f9bc

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -2578,9 +2578,9 @@
 			};
 			name = Release;
 		};
-		083E6364ECF8878A5E1BF8DBF4273815 /* Release */ = {
+		082447C07ACF137BB3DE4FE83F31A2DE /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A1921CDACCA7F9E1DBF6CF26642D14EC /* Swamp-OSX.xcconfig */;
+			baseConfigurationReference = E0DDEDADEE09D1392C279B97017E6AB9 /* Quick-OSX.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2596,14 +2596,14 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_VERSION = A;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Swamp-OSX/Swamp-OSX-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Swamp-OSX/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Quick-OSX/Quick-OSX-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Quick-OSX/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MODULEMAP_FILE = "Target Support Files/Swamp-OSX/Swamp-OSX.modulemap";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MODULEMAP_FILE = "Target Support Files/Quick-OSX/Quick-OSX.modulemap";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = Swamp;
+				PRODUCT_NAME = Quick;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 3.0;
@@ -2612,9 +2612,9 @@
 			};
 			name = Release;
 		};
-		0DE3B2A6231B2062D6B65D37993F8FD1 /* Release */ = {
+		0FB45A386231CFCAF9763F25BD6AE882 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 939D2AF52BD5CA353E51439408AAE2A7 /* CryptoSwift-OSX.xcconfig */;
+			baseConfigurationReference = DAAAC4E246349F11FE4D6EA84D338422 /* SwiftyJSON-OSX.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2630,14 +2630,14 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_VERSION = A;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/CryptoSwift-OSX/CryptoSwift-OSX-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/CryptoSwift-OSX/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/SwiftyJSON-OSX/SwiftyJSON-OSX-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/SwiftyJSON-OSX/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/CryptoSwift-OSX/CryptoSwift-OSX.modulemap";
+				MODULEMAP_FILE = "Target Support Files/SwiftyJSON-OSX/SwiftyJSON-OSX.modulemap";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = CryptoSwift;
+				PRODUCT_NAME = SwiftyJSON;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 3.0;
@@ -2683,9 +2683,9 @@
 			};
 			name = Release;
 		};
-		1A8D918B95AFAAD22DC101D31EFA2990 /* Debug */ = {
+		176DE40E6686FF00A8FBC6F0A0EFB817 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C32A968D97BB8752392E4026DDD8A450 /* Starscream-OSX.xcconfig */;
+			baseConfigurationReference = 47803001C5CD3EEF01E623025204FD86 /* Nimble-OSX.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2693,7 +2693,7 @@
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -2701,57 +2701,21 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_VERSION = A;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Starscream-OSX/Starscream-OSX-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Starscream-OSX/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Nimble-OSX/Nimble-OSX-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Nimble-OSX/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MODULEMAP_FILE = "Target Support Files/Starscream-OSX/Starscream-OSX.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = Starscream;
+				MODULEMAP_FILE = "Target Support Files/Nimble-OSX/Nimble-OSX.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = Nimble;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Debug;
-		};
-		268CE4A3E638B81F03EA94573F804AA7 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = DAAAC4E246349F11FE4D6EA84D338422 /* SwiftyJSON-OSX.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "-";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/SwiftyJSON-OSX/SwiftyJSON-OSX-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/SwiftyJSON-OSX/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/SwiftyJSON-OSX/SwiftyJSON-OSX.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = SwiftyJSON;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
+			name = Release;
 		};
 		330042240752B620FB6FFD4621B95823 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -2818,9 +2782,9 @@
 			};
 			name = Release;
 		};
-		3BCDB132F9AF669C20B3A1922F96DBB5 /* Debug */ = {
+		3FA5A0A8A89539F61A304BD1FB12DFED /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A1921CDACCA7F9E1DBF6CF26642D14EC /* Swamp-OSX.xcconfig */;
+			baseConfigurationReference = C32A968D97BB8752392E4026DDD8A450 /* Starscream-OSX.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2836,14 +2800,14 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_VERSION = A;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Swamp-OSX/Swamp-OSX-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Swamp-OSX/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Starscream-OSX/Starscream-OSX-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Starscream-OSX/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MODULEMAP_FILE = "Target Support Files/Swamp-OSX/Swamp-OSX.modulemap";
+				MODULEMAP_FILE = "Target Support Files/Starscream-OSX/Starscream-OSX.modulemap";
 				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = Swamp;
+				PRODUCT_NAME = Starscream;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -2853,9 +2817,9 @@
 			};
 			name = Debug;
 		};
-		50836959BC02EDA1B112EBD593C53F41 /* Debug */ = {
+		508686E4BA1FF6002D3A98F508D65A60 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 47803001C5CD3EEF01E623025204FD86 /* Nimble-OSX.xcconfig */;
+			baseConfigurationReference = C32A968D97BB8752392E4026DDD8A450 /* Starscream-OSX.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2863,7 +2827,7 @@
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -2871,22 +2835,21 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_VERSION = A;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Nimble-OSX/Nimble-OSX-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Nimble-OSX/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Starscream-OSX/Starscream-OSX-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Starscream-OSX/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MODULEMAP_FILE = "Target Support Files/Nimble-OSX/Nimble-OSX.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = Nimble;
+				MODULEMAP_FILE = "Target Support Files/Starscream-OSX/Starscream-OSX.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = Starscream;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Debug;
+			name = Release;
 		};
 		67FDCFE3B8A0089C0279AFD6D72BEC53 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -2924,145 +2887,7 @@
 			};
 			name = Debug;
 		};
-		685D287CF3E57EB7849C2A5CD1147311 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E0DDEDADEE09D1392C279B97017E6AB9 /* Quick-OSX.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "-";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Quick-OSX/Quick-OSX-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Quick-OSX/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/Quick-OSX/Quick-OSX.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = Quick;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		69002227F5BC2ABCEB25FBFA2B223DC2 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 939D2AF52BD5CA353E51439408AAE2A7 /* CryptoSwift-OSX.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "-";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/CryptoSwift-OSX/CryptoSwift-OSX-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/CryptoSwift-OSX/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/CryptoSwift-OSX/CryptoSwift-OSX.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = CryptoSwift;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		6E0F9BEBFF825587762C2F41D0BEBB0E /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C32A968D97BB8752392E4026DDD8A450 /* Starscream-OSX.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "-";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Starscream-OSX/Starscream-OSX-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Starscream-OSX/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MODULEMAP_FILE = "Target Support Files/Starscream-OSX/Starscream-OSX.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = Starscream;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		6E1CD5063AFDC211ED999BCC9D4E1164 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E0DDEDADEE09D1392C279B97017E6AB9 /* Quick-OSX.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "-";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Quick-OSX/Quick-OSX-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Quick-OSX/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/Quick-OSX/Quick-OSX.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = Quick;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		80127EACDC741210C2AFCD53198B0392 /* Release */ = {
+		6BD2889C983064C4607643943E4F9347 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 47803001C5CD3EEF01E623025204FD86 /* Nimble-OSX.xcconfig */;
 			buildSettings = {
@@ -3072,7 +2897,7 @@
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -3086,15 +2911,16 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MODULEMAP_FILE = "Target Support Files/Nimble-OSX/Nimble-OSX.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_NAME = Nimble;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Release;
+			name = Debug;
 		};
 		859ACE7CA6B6B5AAB33D38C85EC5421B /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -3164,6 +2990,41 @@
 			};
 			name = Debug;
 		};
+		892072957DA4A8C2AA194CA495DAF68C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = DAAAC4E246349F11FE4D6EA84D338422 /* SwiftyJSON-OSX.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/SwiftyJSON-OSX/SwiftyJSON-OSX-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/SwiftyJSON-OSX/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MODULEMAP_FILE = "Target Support Files/SwiftyJSON-OSX/SwiftyJSON-OSX.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = SwiftyJSON;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		8DD423BFF75E71A0C63AB13CD6A2F716 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1FBC22BC0703BA80F3ADABC1F4C557A5 /* CryptoSwift-iOS.xcconfig */;
@@ -3195,6 +3056,76 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
+		};
+		9639EEA5D0A6099F91AB56E2BA21C093 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 939D2AF52BD5CA353E51439408AAE2A7 /* CryptoSwift-OSX.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/CryptoSwift-OSX/CryptoSwift-OSX-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/CryptoSwift-OSX/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MODULEMAP_FILE = "Target Support Files/CryptoSwift-OSX/CryptoSwift-OSX.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = CryptoSwift;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		9CF36050A810981DB7FA3AAE17BC65BB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E0DDEDADEE09D1392C279B97017E6AB9 /* Quick-OSX.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Quick-OSX/Quick-OSX-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Quick-OSX/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MODULEMAP_FILE = "Target Support Files/Quick-OSX/Quick-OSX.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = Quick;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
 		};
 		A27048865BD815FD729E9164D215E47E /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -3347,9 +3278,9 @@
 			};
 			name = Release;
 		};
-		B70E8E5A766676FC2E485F2B0E2B315F /* Release */ = {
+		BCDCC1C4B3C3E35C4A8BA019A4193DD6 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DAAAC4E246349F11FE4D6EA84D338422 /* SwiftyJSON-OSX.xcconfig */;
+			baseConfigurationReference = 939D2AF52BD5CA353E51439408AAE2A7 /* CryptoSwift-OSX.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3365,14 +3296,14 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_VERSION = A;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/SwiftyJSON-OSX/SwiftyJSON-OSX-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/SwiftyJSON-OSX/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/CryptoSwift-OSX/CryptoSwift-OSX-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/CryptoSwift-OSX/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/SwiftyJSON-OSX/SwiftyJSON-OSX.modulemap";
+				MODULEMAP_FILE = "Target Support Files/CryptoSwift-OSX/CryptoSwift-OSX.modulemap";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = SwiftyJSON;
+				PRODUCT_NAME = CryptoSwift;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 3.0;
@@ -3582,14 +3513,83 @@
 			};
 			name = Debug;
 		};
+		F762DA7DB761F6FD371E1109A6901AF0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A1921CDACCA7F9E1DBF6CF26642D14EC /* Swamp-OSX.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Swamp-OSX/Swamp-OSX-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Swamp-OSX/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MODULEMAP_FILE = "Target Support Files/Swamp-OSX/Swamp-OSX.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = Swamp;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		FD3782C3C4FA33571B9D39033F22BFD2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A1921CDACCA7F9E1DBF6CF26642D14EC /* Swamp-OSX.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Swamp-OSX/Swamp-OSX-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Swamp-OSX/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MODULEMAP_FILE = "Target Support Files/Swamp-OSX/Swamp-OSX.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = Swamp;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
 		0420C263C1133B010AC72D2C33D6E122 /* Build configuration list for PBXNativeTarget "Nimble-OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				50836959BC02EDA1B112EBD593C53F41 /* Debug */,
-				80127EACDC741210C2AFCD53198B0392 /* Release */,
+				6BD2889C983064C4607643943E4F9347 /* Debug */,
+				176DE40E6686FF00A8FBC6F0A0EFB817 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3606,8 +3606,8 @@
 		6C2577210EF5110893C592865418AD7E /* Build configuration list for PBXNativeTarget "Quick-OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				685D287CF3E57EB7849C2A5CD1147311 /* Debug */,
-				6E1CD5063AFDC211ED999BCC9D4E1164 /* Release */,
+				9CF36050A810981DB7FA3AAE17BC65BB /* Debug */,
+				082447C07ACF137BB3DE4FE83F31A2DE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3624,8 +3624,8 @@
 		92A6078185E751163137F557572E0DA8 /* Build configuration list for PBXNativeTarget "Starscream-OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				1A8D918B95AFAAD22DC101D31EFA2990 /* Debug */,
-				6E0F9BEBFF825587762C2F41D0BEBB0E /* Release */,
+				3FA5A0A8A89539F61A304BD1FB12DFED /* Debug */,
+				508686E4BA1FF6002D3A98F508D65A60 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3651,8 +3651,8 @@
 		9D847066A412327C25634C06B658E347 /* Build configuration list for PBXNativeTarget "Swamp-OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				3BCDB132F9AF669C20B3A1922F96DBB5 /* Debug */,
-				083E6364ECF8878A5E1BF8DBF4273815 /* Release */,
+				F762DA7DB761F6FD371E1109A6901AF0 /* Debug */,
+				FD3782C3C4FA33571B9D39033F22BFD2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3678,8 +3678,8 @@
 		A5EC9D4616C331FA4B1688B9BA644B69 /* Build configuration list for PBXNativeTarget "SwiftyJSON-OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				268CE4A3E638B81F03EA94573F804AA7 /* Debug */,
-				B70E8E5A766676FC2E485F2B0E2B315F /* Release */,
+				892072957DA4A8C2AA194CA495DAF68C /* Debug */,
+				0FB45A386231CFCAF9763F25BD6AE882 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3705,8 +3705,8 @@
 		CEB6FD5CF38FB7E0F12ED2128BAAD9DF /* Build configuration list for PBXNativeTarget "CryptoSwift-OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				69002227F5BC2ABCEB25FBFA2B223DC2 /* Debug */,
-				0DE3B2A6231B2062D6B65D37993F8FD1 /* Release */,
+				9639EEA5D0A6099F91AB56E2BA21C093 /* Debug */,
+				BCDCC1C4B3C3E35C4A8BA019A4193DD6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/Pods/Target Support Files/Swamp-OSX/Info.plist
+++ b/Example/Pods/Target Support Files/Swamp-OSX/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.1.2</string>
+  <string>0.2.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/Swamp-iOS/Info.plist
+++ b/Example/Pods/Target Support Files/Swamp-iOS/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.1.2</string>
+  <string>0.2.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Swamp.xcodeproj/project.pbxproj
+++ b/Example/Swamp.xcodeproj/project.pbxproj
@@ -202,7 +202,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0810;
 				ORGANIZATIONNAME = CocoaPods;
 				TargetAttributes = {
 					905F75B91D80A36400D16B4F = {
@@ -381,7 +381,8 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Developer: danysousa.sd@gmail.com (GMM3899955)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: danysousa.sd@gmail.com (GMM3899955)";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -428,6 +429,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/Example/Swamp.xcodeproj/xcshareddata/xcschemes/Swamp_Test-OSX.xcscheme
+++ b/Example/Swamp.xcodeproj/xcshareddata/xcschemes/Swamp_Test-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0810"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/Swamp.xcodeproj/xcshareddata/xcschemes/Swamp_Test-iOS.xcscheme
+++ b/Example/Swamp.xcodeproj/xcshareddata/xcschemes/Swamp_Test-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0810"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/Tests/CrossbarIntegrationTests.swift
+++ b/Example/Tests/CrossbarIntegrationTests.swift
@@ -8,7 +8,7 @@ import Swamp
 class TestSessionDelegate: SwampSessionDelegate {
     // For testing purposes
     var reasonEnded: String? = nil
-    var sessionId: Int? = nil
+    var sessionId: NSNumber? = nil
 
     func swampSessionHandleChallenge(_ authMethod: String, extra: [String : Any]) -> String {
         fatalError("Should be overriden, if needed")
@@ -18,7 +18,7 @@ class TestSessionDelegate: SwampSessionDelegate {
         self.reasonEnded = reason
     }
 
-    func swampSessionConnected(_ session: SwampSession, sessionId: Int) {
+    func swampSessionConnected(_ session: SwampSession, sessionId: NSNumber) {
         self.sessionId = sessionId
     }
 }

--- a/Swamp/Messages/Auth/AuthenticateSwampMessage.swift
+++ b/Swamp/Messages/Auth/AuthenticateSwampMessage.swift
@@ -11,22 +11,22 @@ import SwiftyJSON
 
 /// [AUTHENTICATE, signature|string, extra|dict]
 class AuthenticateSwampMessage: SwampMessage {
-    
+
     let signature: String
     let extra: [String: Any]
-    
-    init(signature: String, extra: [String: AnyObject]) {
+
+    init(signature: String, extra: [String: Any]) {
         self.signature = signature
         self.extra = extra
     }
-    
+
     // MARK: SwampMessage protocol
-    
+
     required init(payload: [Any]) {
         self.signature  = payload[0] as! String
         self.extra = payload[1] as! [String: Any]
     }
-    
+
     func marshal() -> [Any] {
         return [SwampMessages.authenticate.rawValue, self.signature, self.extra]
     }

--- a/Swamp/Messages/PubSub/Publisher/PublishedSwampMessage.swift
+++ b/Swamp/Messages/PubSub/Publisher/PublishedSwampMessage.swift
@@ -10,21 +10,21 @@ import Foundation
 
 /// [PUBLISHED, requestId|number, options|dict, topic|String, args|list?, kwargs|dict?]
 class PublishedSwampMessage: SwampMessage {
-    
+
     let requestId: Int
-    let publication: Int
-    
-    init(requestId: Int, publication: Int) {
+    let publication: NSNumber
+
+    init(requestId: Int, publication: NSNumber) {
         self.requestId = requestId
         self.publication = publication
     }
-    
+
     // MARK: SwampMessage protocol
     required init(payload: [Any]) {
         self.requestId = payload[0] as! Int
-        self.publication = payload[1] as! Int
+        self.publication = payload[1] as! NSNumber
     }
-    
+
     func marshal() -> [Any] {
         let marshalled: [Any] = [SwampMessages.published.rawValue, self.requestId, self.publication]
         return marshalled

--- a/Swamp/Messages/PubSub/Subscriber/EventSwampMessage.swift
+++ b/Swamp/Messages/PubSub/Subscriber/EventSwampMessage.swift
@@ -10,36 +10,36 @@ import Foundation
 
 /// [EVENT, subscription|number, publication|number, details|dict, args|list?, kwargs|dict?]
 class EventSwampMessage: SwampMessage {
-    
-    let subscription: Int
-    let publication: Int
-    let details: [String: AnyObject]
-    
-    let args: [AnyObject]?
-    let kwargs: [String: AnyObject]?
-    
-    init(subscription: Int, publication: Int, details: [String: AnyObject], args: [AnyObject]?=nil, kwargs: [String: AnyObject]?=nil) {
+
+    let subscription: NSNumber
+    let publication: NSNumber
+    let details: [String: Any]
+
+    let args: [Any]?
+    let kwargs: [String: Any]?
+
+    init(subscription: NSNumber, publication: NSNumber, details: [String: Any], args: [Any]?=nil, kwargs: [String: Any]?=nil) {
         self.subscription = subscription
         self.publication = publication
         self.details = details
-        
+
         self.args = args
         self.kwargs = kwargs
     }
-    
+
     // MARK: SwampMessage protocol
-    
+
     required init(payload: [Any]) {
-        self.subscription = payload[0] as! Int
-        self.publication = payload[1] as! Int
-        self.details = payload[2] as! [String: AnyObject]
-        self.args = payload[safe: 3] as? [AnyObject]
-        self.kwargs = payload[safe: 4] as? [String: AnyObject]
+        self.subscription = (payload[0] as! NSNumber)
+        self.publication = (payload[1] as! NSNumber)
+        self.details = payload[2] as! [String: Any]
+        self.args = payload[safe: 3] as? [Any]
+        self.kwargs = payload[safe: 4] as? [String: Any]
     }
-    
+
     func marshal() -> [Any] {
         var marshalled: [Any] = [SwampMessages.event.rawValue, self.subscription, self.publication, self.details]
-        
+
         if let args = self.args {
             marshalled.append(args)
             if let kwargs = self.kwargs {
@@ -51,7 +51,7 @@ class EventSwampMessage: SwampMessage {
                 marshalled.append(kwargs)
             }
         }
-        
+
         return marshalled
     }
 }

--- a/Swamp/Messages/PubSub/Subscriber/SubscribedSwampMessage.swift
+++ b/Swamp/Messages/PubSub/Subscriber/SubscribedSwampMessage.swift
@@ -10,22 +10,22 @@ import Foundation
 
 /// [SUBSCRIBED, requestId|number, subscription|number]
 class SubscribedSwampMessage: SwampMessage {
-    
+
     let requestId: Int
-    let subscription: Int
-    
-    init(requestId: Int, subscription: Int) {
+    let subscription: NSNumber
+
+    init(requestId: Int, subscription: NSNumber) {
         self.requestId = requestId
         self.subscription = subscription
     }
-    
+
     // MARK: SwampMessage protocol
-    
+
     required init(payload: [Any]) {
         self.requestId = payload[0] as! Int
-        self.subscription = payload[1] as! Int
+        self.subscription = payload[1] as! NSNumber
     }
-    
+
     func marshal() -> [Any] {
         return [SwampMessages.subscribed.rawValue, self.requestId, self.subscription]
     }

--- a/Swamp/Messages/PubSub/Subscriber/UnsubscribeSwampMessage.swift
+++ b/Swamp/Messages/PubSub/Subscriber/UnsubscribeSwampMessage.swift
@@ -10,22 +10,22 @@ import Foundation
 
 /// [UNSUBSCRIBE, requestId|number, subscription|number]
 class UnsubscribeSwampMessage: SwampMessage {
-    
+
     let requestId: Int
-    let subscription: Int
-    
-    init(requestId: Int, subscription: Int) {
+    let subscription: NSNumber
+
+    init(requestId: Int, subscription: NSNumber) {
         self.requestId = requestId
         self.subscription = subscription
     }
-    
+
     // MARK: SwampMessage protocol
-    
+
     required init(payload: [Any]) {
         self.requestId = payload[0] as! Int
-        self.subscription = payload[1] as! Int
+        self.subscription = payload[1] as! NSNumber
     }
-    
+
     func marshal() -> [Any] {
         return [SwampMessages.unsubscribe.rawValue, self.requestId, self.subscription]
     }

--- a/Swamp/Messages/RPC/Callee/InvocationSwampMessage.swift
+++ b/Swamp/Messages/RPC/Callee/InvocationSwampMessage.swift
@@ -10,36 +10,36 @@ import Foundation
 
 // [INVOCATION, requestId|number, registration|number, details|dict, args|array?, kwargs|dict?]
 class InvocationSwampMessage: SwampMessage {
-    
+
     let requestId: Int
-    let registration: Int
-    let details: [String: AnyObject]
-    
-    let args: [AnyObject]?
-    let kwargs: [String: AnyObject]?
-    
-    init(requestId: Int, registration: Int, details: [String: AnyObject], args: [AnyObject]?=nil, kwargs: [String: AnyObject]?=nil) {
+    let registration: NSNumber
+    let details: [String: Any]
+
+    let args: [Any]?
+    let kwargs: [String: Any]?
+
+    init(requestId: Int, registration: NSNumber, details: [String: Any], args: [Any]?=nil, kwargs: [String: Any]?=nil) {
         self.requestId = requestId
         self.registration = registration
         self.details = details
-        
+
         self.args = args
         self.kwargs = kwargs
     }
-    
+
     // MARK: SwampMessage protocol
-    
+
     required init(payload: [Any]) {
         self.requestId = payload[0] as! Int
-        self.registration = payload[1] as! Int
-        self.details = payload[2] as! [String: AnyObject]
-        self.args = payload[safe: 3] as? [AnyObject]
-        self.kwargs = payload[safe: 4] as? [String: AnyObject]
+        self.registration = payload[1] as! NSNumber
+        self.details = payload[2] as! [String: Any]
+        self.args = payload[safe: 3] as? [Any]
+        self.kwargs = payload[safe: 4] as? [String: Any]
     }
-    
+
     func marshal() -> [Any] {
         var marshalled: [Any] = [SwampMessages.invocation.rawValue, self.requestId, self.registration, self.details]
-        
+
         if let args = self.args {
             marshalled.append(args)
             if let kwargs = self.kwargs {
@@ -51,7 +51,7 @@ class InvocationSwampMessage: SwampMessage {
                 marshalled.append(kwargs)
             }
         }
-        
+
         return marshalled
     }
 }

--- a/Swamp/Messages/RPC/Callee/RegisterSwampMessage.swift
+++ b/Swamp/Messages/RPC/Callee/RegisterSwampMessage.swift
@@ -10,24 +10,24 @@ import Foundation
 
 /// [Register, requestId|number, options|dict, proc|string]
 class RegisterSwampMessage: SwampMessage {
-    
+
     let requestId: Int
-    let options: [String: AnyObject]
+    let options: [String: Any]
     let proc: String
-    
-    init(requestId: Int, options: [String: AnyObject], proc: String) {
+
+    init(requestId: Int, options: [String: Any], proc: String) {
         self.requestId = requestId
         self.options = options
         self.proc = proc
     }
-    
+
     // MARK: SwampMessage protocol
     required init(payload: [Any]) {
         self.requestId = payload[0] as! Int
-        self.options = payload[1] as! [String: AnyObject]
+        self.options = payload[1] as! [String: Any]
         self.proc = payload[2] as! String
     }
-    
+
     func marshal() -> [Any] {
         return [SwampMessages.register.rawValue, self.requestId, self.options, self.proc]
     }

--- a/Swamp/Messages/RPC/Callee/RegisteredSwampMessage.swift
+++ b/Swamp/Messages/RPC/Callee/RegisteredSwampMessage.swift
@@ -10,22 +10,22 @@ import Foundation
 
 /// [REGISTERED, requestId|number, registration|number]
 class RegisteredSwampMessage: SwampMessage {
-    
+
     let requestId: Int
-    let registration: Int
-    
-    init(requestId: Int, registration: Int) {
+    let registration: NSNumber
+
+    init(requestId: Int, registration: NSNumber) {
         self.requestId = requestId
         self.registration = registration
     }
-    
+
     // MARK: SwampMessage protocol
-    
+
     required init(payload: [Any]) {
         self.requestId = payload[0] as! Int
-        self.registration = payload[1] as! Int
+        self.registration = payload[1] as! NSNumber
     }
-    
+
     func marshal() -> [Any] {
         return [SwampMessages.registered.rawValue, self.requestId, self.registration]
     }

--- a/Swamp/Messages/RPC/Callee/UnregisterSwampMessage.swift
+++ b/Swamp/Messages/RPC/Callee/UnregisterSwampMessage.swift
@@ -10,22 +10,22 @@ import Foundation
 
 /// [UNREGISTER, requestId|number, registration|number]
 class UnregisterSwampMessage: SwampMessage {
-    
+
     let requestId: Int
-    let registration: Int
-    
-    init(requestId: Int, registration: Int) {
+    let registration: NSNumber
+
+    init(requestId: Int, registration: NSNumber) {
         self.requestId = requestId
         self.registration = registration
     }
-    
+
     // MARK: SwampMessage protocol
-    
+
     required init(payload: [Any]) {
         self.requestId = payload[0] as! Int
-        self.registration = payload[1] as! Int
+        self.registration = payload[1] as! NSNumber
     }
-    
+
     func marshal() -> [Any] {
         return [SwampMessages.unregister.rawValue, self.requestId, self.registration]
     }

--- a/Swamp/Messages/RPC/Callee/YieldSwampMessage.swift
+++ b/Swamp/Messages/RPC/Callee/YieldSwampMessage.swift
@@ -10,45 +10,45 @@ import Foundation
 
 // [YIELD, requestId|number, options|dict, args|array?, kwargs|dict?]
 class YieldSwampMessage: SwampMessage {
-    
+
     let requestId: Int
-    let options: [String: AnyObject]
-    
-    let args: [AnyObject]?
-    let kwargs: [String: AnyObject]?
-    
-    init(requestId: Int, options: [String: AnyObject], args: [AnyObject]?=nil, kwargs: [String: AnyObject]?=nil) {
+    let options: [String: Any]
+
+    let args: [Any]?
+    let kwargs: [String: Any]?
+
+    init(requestId: Int, options: [String: Any], args: [Any]?=nil, kwargs: [String: Any]?=nil) {
         self.requestId = requestId
         self.options = options
-        
+
         self.args = args
         self.kwargs = kwargs
     }
-    
+
     // MARK: SwampMessage protocol
-    
+
     required init(payload: [Any]) {
         self.requestId = payload[0] as! Int
-        self.options = payload[1] as! [String: AnyObject]
-        self.args = payload[safe: 2] as? [AnyObject]
-        self.kwargs = payload[safe: 3] as? [String: AnyObject]
+        self.options = payload[1] as! [String: Any]
+        self.args = payload[safe: 2] as? [Any]
+        self.kwargs = payload[safe: 3] as? [String: Any]
     }
-    
+
     func marshal() -> [Any] {
         var marshalled: [Any] = [SwampMessages.yield.rawValue, self.requestId, self.options]
-        
+
         if let args = self.args {
-            marshalled.append(args as AnyObject)
+            marshalled.append(args)
             if let kwargs = self.kwargs {
-                marshalled.append(kwargs as AnyObject)
+                marshalled.append(kwargs)
             }
         } else {
             if let kwargs = self.kwargs {
                 marshalled.append([])
-                marshalled.append(kwargs as AnyObject)
+                marshalled.append(kwargs)
             }
         }
-        
+
         return marshalled
     }
 }

--- a/Swamp/Messages/RPC/Caller/CallSwampMessage.swift
+++ b/Swamp/Messages/RPC/Caller/CallSwampMessage.swift
@@ -10,13 +10,13 @@ import Foundation
 
 /// [CALL, requestId|number, options|dict, proc|string, args|array?, kwargs|dict?]
 class CallSwampMessage: SwampMessage {
-    
+
     let requestId: Int
     let options: [String: Any]
     let proc: String
     let args: [Any]?
     let kwargs: [String: Any]?
-    
+
     init(requestId: Int, options: [String: Any], proc: String, args: [Any]?=nil, kwargs: [String: Any]?=nil) {
         self.requestId = requestId
         self.options = options
@@ -24,20 +24,20 @@ class CallSwampMessage: SwampMessage {
         self.args = args
         self.kwargs = kwargs
     }
-    
+
     /// MARK: SwampMessage protocol
-    
+
     required init(payload: [Any]) {
         self.requestId = payload[0] as! Int
         self.options = payload[1] as! [String: Any]
         self.proc = payload[2] as! String
-        self.args = payload[safe: 3] as? [AnyObject]
+        self.args = payload[safe: 3] as? [Any]
         self.kwargs = payload[safe: 4] as? [String: Any]
     }
-    
+
     func marshal() -> [Any] {
         var marshalled: [Any] = [SwampMessages.call.rawValue, self.requestId, self.options, self.proc]
-        
+
         if let args = self.args {
             marshalled.append(args)
             if let kwargs = self.kwargs {
@@ -49,8 +49,8 @@ class CallSwampMessage: SwampMessage {
                 marshalled.append(kwargs)
             }
         }
-        
+
         return marshalled
     }
-    
+
 }

--- a/Swamp/Messages/RPC/Caller/ResultSwampMessage.swift
+++ b/Swamp/Messages/RPC/Caller/ResultSwampMessage.swift
@@ -10,31 +10,31 @@ import Foundation
 
 /// [RESULT, requestId|number, details|dict, args|array?, kwargs|dict?]
 class ResultSwampMessage: SwampMessage {
-    
+
     let requestId: Int
-    let details: [String: AnyObject]
-    let results: [AnyObject]?
-    let kwResults: [String: AnyObject]?
-    
-    init(requestId: Int, details: [String: AnyObject], results: [AnyObject]?=nil, kwResults: [String: AnyObject]?=nil) {
+    let details: [String: Any]
+    let results: [Any]?
+    let kwResults: [String: Any]?
+
+    init(requestId: Int, details: [String: Any], results: [Any]?=nil, kwResults: [String: Any]?=nil) {
         self.requestId = requestId
         self.details = details
         self.results = results
         self.kwResults = kwResults
     }
-    
+
     /// MARK: SwampMessage protocol
-    
+
     required init(payload: [Any]) {
         self.requestId = payload[0] as! Int
-        self.details = payload[1] as! [String: AnyObject]
-        self.results  = payload[safe: 2] as? [AnyObject]
-        self.kwResults = payload[safe: 3] as? [String: AnyObject]
+        self.details = payload[1] as! [String: Any]
+        self.results  = payload[safe: 2] as? [Any]
+        self.kwResults = payload[safe: 3] as? [String: Any]
     }
-    
+
     func marshal() -> [Any] {
         var marshalled: [Any] = [SwampMessages.result.rawValue, self.requestId, self.details]
-        
+
         if let results = self.results {
             marshalled.append(results)
             if let kwResults = self.kwResults {
@@ -46,8 +46,8 @@ class ResultSwampMessage: SwampMessage {
                 marshalled.append(kwResults)
             }
         }
-        
+
         return marshalled
     }
-    
+
 }

--- a/Swamp/Messages/Session/AbortSwampMessage.swift
+++ b/Swamp/Messages/Session/AbortSwampMessage.swift
@@ -11,22 +11,22 @@ import SwiftyJSON
 
 /// [ABORT, details|dict, reason|uri]
 class AbortSwampMessage: SwampMessage {
-    
-    let details: [String: AnyObject]
+
+    let details: [String: Any]
     let reason: String
-    
-    init(details: [String: AnyObject], reason: String) {
+
+    init(details: [String: Any], reason: String) {
         self.details = details
         self.reason = reason
     }
-    
+
     // MARK: SwampMessage protocol
-    
+
     required init(payload: [Any]) {
-        self.details = payload[0] as! [String: AnyObject]
+        self.details = payload[0] as! [String: Any]
         self.reason = payload[1] as! String
     }
-    
+
     func marshal() -> [Any] {
         return [SwampMessages.abort.rawValue, self.details, self.reason]
     }

--- a/Swamp/Messages/Session/GoodbyeSwampMessage.swift
+++ b/Swamp/Messages/Session/GoodbyeSwampMessage.swift
@@ -11,22 +11,22 @@ import SwiftyJSON
 
 /// [GOODBYE, details|dict, reason|uri]
 class GoodbyeSwampMessage: SwampMessage {
-    
-    let details: [String: AnyObject]
+
+    let details: [String: Any]
     let reason: String
-    
-    init(details: [String: AnyObject], reason: String) {
+
+    init(details: [String: Any], reason: String) {
         self.details = details
         self.reason = reason
     }
-    
+
     // MARK: SwampMessage protocol
-    
+
     required init(payload: [Any]) {
-        self.details = payload[0] as! [String: AnyObject]
+        self.details = payload[0] as! [String: Any]
         self.reason = payload[1] as! String
     }
-    
+
     func marshal() -> [Any] {
         return [SwampMessages.goodbye.rawValue, self.details, self.reason]
     }

--- a/Swamp/Messages/Session/WelcomeSwampMessage.swift
+++ b/Swamp/Messages/Session/WelcomeSwampMessage.swift
@@ -11,22 +11,23 @@ import SwiftyJSON
 
 /// [WELCOME, sessionId|number, details|Dict]
 class WelcomeSwampMessage: SwampMessage {
-    
-    let sessionId: Int
-    let details: [String: AnyObject]
-    
-    init(sessionId: Int, details: [String: AnyObject]) {
+
+    let sessionId: NSNumber
+    let details: [String: Any]
+
+    init(sessionId: NSNumber, details: [String: Any]) {
         self.sessionId = sessionId
         self.details = details
     }
-    
+
     // MARK: SwampMessage protocol
-    
+
     required init(payload: [Any]) {
-        self.sessionId = payload[0] as! Int
-        self.details = payload[1] as! [String: AnyObject]
+        self.sessionId = payload[0] as! NSNumber
+
+        self.details = payload[1] as! [String: Any]
     }
-    
+
     func marshal() -> [Any] {
         return [SwampMessages.welcome.rawValue, self.sessionId, self.details]
     }

--- a/Swamp/SwampSession.swift
+++ b/Swamp/SwampSession.swift
@@ -28,11 +28,11 @@ public typealias ErrorPublishCallback = (_ details: [String: Any], _ error: Stri
 // TODO: Expose only an interface (like Cancellable) to user
 open class Subscription {
     fileprivate let session: SwampSession
-    internal let subscription: Int
+    internal let subscription: NSNumber
     internal let eventCallback: EventCallback
     fileprivate var isActive: Bool = true
 
-    internal init(session: SwampSession, subscription: Int, onEvent: @escaping EventCallback) {
+    internal init(session: SwampSession, subscription: NSNumber, onEvent: @escaping EventCallback) {
         self.session = session
         self.subscription = subscription
         self.eventCallback = onEvent
@@ -57,7 +57,7 @@ open class Subscription {
 
 public protocol SwampSessionDelegate {
     func swampSessionHandleChallenge(_ authMethod: String, extra: [String: Any]) -> String
-    func swampSessionConnected(_ session: SwampSession, sessionId: Int)
+    func swampSessionConnected(_ session: SwampSession, sessionId: NSNumber)
     func swampSessionEnded(_ reason: String)
 }
 
@@ -85,7 +85,7 @@ open class SwampSession: SwampTransportDelegate {
 
     // MARK: Session state
     fileprivate var serializer: SwampSerializer?
-    fileprivate var sessionId: Int?
+    fileprivate var sessionId: NSNumber?
     fileprivate var routerSupportedRoles: [SwampRole]?
 
     // MARK: Call role
@@ -96,9 +96,9 @@ open class SwampSession: SwampTransportDelegate {
     //                              requestId
     fileprivate var subscribeRequests: [Int: (callback: SubscribeCallback, errorCallback: ErrorSubscribeCallback, eventCallback: EventCallback)] = [:]
     //                          subscription
-    fileprivate var subscriptions: [Int: Subscription] = [:]
+    fileprivate var subscriptions: [NSNumber: Subscription] = [:]
     //                                requestId
-    fileprivate var unsubscribeRequests: [Int: (subscription: Int, callback: UnsubscribeCallback, errorCallback: ErrorUnsubscribeCallback)] = [:]
+    fileprivate var unsubscribeRequests: [Int: (subscription: NSNumber, callback: UnsubscribeCallback, errorCallback: ErrorUnsubscribeCallback)] = [:]
 
     // MARK: Publisher role
     //                            requestId
@@ -155,7 +155,10 @@ open class SwampSession: SwampTransportDelegate {
     }
 
     // Internal because only a Subscription object can call this
-    internal func unsubscribe(_ subscription: Int, onSuccess: @escaping UnsubscribeCallback, onError: @escaping ErrorUnsubscribeCallback) {
+    internal func unsubscribe(_ subscription: NSNumber,
+                              onSuccess: @escaping UnsubscribeCallback,
+                              onError: @escaping ErrorUnsubscribeCallback) {
+
         let unsubscribeRequestId = self.generateRequestId()
         // Tell router to unsubscribe me from some subscription
         self.sendMessage(UnsubscribeSwampMessage(requestId: unsubscribeRequestId, subscription: subscription))


### PR DESCRIPTION
I have Int overflow when crossbar return send the request Id.
I Use NSNumber instead Int, because the request id (subscribe id for example) is an int64, but JSON serializer doesn't accept Int64, so I change Int to NSNumber for compatibility with serializers and overflow preventions.