### PR TITLE
fixed compile error

### DIFF
--- a/Swamp/SwampSession.swift
+++ b/Swamp/SwampSession.swift
@@ -74,7 +74,7 @@ open class SwampSession: SwampTransportDelegate {
 
     // MARK: Members
     fileprivate let realm: String
-    fileprivate let transport: SwampTransport
+    fileprivate var transport: SwampTransport
     fileprivate let authmethods: [String]?
     fileprivate let authid: String?
     fileprivate let authrole: String?


### PR DESCRIPTION
I was getting and error that the transport constant is let and could not be written to even though you're assigning to it in the initializer. Maybe because its assigning with self? Could be a bug with swift